### PR TITLE
Fix footer

### DIFF
--- a/src/BaseLayout/Footer.tsx
+++ b/src/BaseLayout/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography, Link } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { colors } from "../styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
@@ -9,7 +9,7 @@ import { homePageLinks } from "../const";
 
 const { officialBackgroundColor } = colors;
 
-const Footer: React.FC = () => {
+function Footer() {
   const isMobile = useMediaQuery("(max-width:758px)");
   return (
     <Box
@@ -26,9 +26,9 @@ const Footer: React.FC = () => {
         display: "flex",
         flexWrap: "wrap",
         gap: 2,
-        maxHeight: "30px",
+        maxHeight: isMobile ? "none" : "30px",
         alignContent: isMobile ? "start" : "end",
-        flexDirection: "row",
+        flexDirection: isMobile ? "column" : "row",
         position: "sticky",
         bottom: 0,
         width: "100%",
@@ -37,9 +37,9 @@ const Footer: React.FC = () => {
       {Object.entries(homePageLinks).map(([key, link]) => (
         <Box key={key}>
           <Typography variant="body2">
-            <Link href={link.url} color="black" underline="none">
+            <a href={link.url} style={{ color: "black", textDecoration: "none" }}>
               {link.label}
-            </Link>
+            </a>
           </Typography>
         </Box>
       ))}

--- a/src/BaseLayout/Footer.tsx
+++ b/src/BaseLayout/Footer.tsx
@@ -34,7 +34,9 @@ function Footer() {
         width: "100%",
       }}
     >
-      {Object.entries(homePageLinks).map(([key, link]) => (
+      {Object.entries(homePageLinks)
+        .filter(([, link]) => link.type === "link")
+        .map(([key, link]) => (
         <Box key={key}>
           <Typography variant="body2">
             <a href={link.url} style={{ color: "black", textDecoration: "none" }}>

--- a/src/BaseLayout/index.tsx
+++ b/src/BaseLayout/index.tsx
@@ -6,7 +6,6 @@ import { ThemeProvider } from "@mui/material/styles";
 import theme from "../theme";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import Box from "@mui/material/Box";
-import { Link } from "gatsby";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -82,12 +81,12 @@ const BaseLayout: React.FC<LayoutProps> = ({ children, isHomePage }) => {
             maxWidth: "100%",
           }}
         >
-          <Link to="/">
+          <a href="/">
             <Box sx={setHeaderStyles} className="header--wrapper">
               {/* need to create a unique logo*/}
               <Box sx={boxStylesToCenter} />
             </Box>
-          </Link>
+          </a>
         </Grid>
 
         {children}

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -13,10 +13,8 @@ function isInternalLink(url: string): boolean {
   return url.startsWith("/") && !url.startsWith("//");
 }
 
-const VIDEO_TITLE = "Watch the SoulPad Video";
-
 function getYouTubeEmbedUrl(url: string): string {
-  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&]+)/);
+  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&?]+)/);
   return match ? `https://www.youtube.com/embed/${match[1]}?autoplay=1` : url;
 }
 
@@ -43,8 +41,21 @@ function LinkWrapper({
   };
 
   if (isVideoLink) {
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onVideoClick();
+      }
+    };
     return (
-      <Box component="span" onClick={onVideoClick} sx={videoSx}>
+      <Box
+        component="span"
+        role="button"
+        tabIndex={0}
+        onClick={onVideoClick}
+        onKeyDown={handleKeyDown}
+        sx={videoSx}
+      >
         {children}
       </Box>
     );
@@ -73,6 +84,7 @@ function LinkWrapper({
 interface WindowProps {
   title: string;
   link: string;
+  type?: "link" | "video";
   maxWidth: string;
   minHeight: string;
 }
@@ -80,11 +92,12 @@ interface WindowProps {
 const Windows: React.FC<WindowProps> = ({
   title,
   link,
+  type = "link",
   maxWidth,
   minHeight,
 }) => {
   const [videoModalOpen, setVideoModalOpen] = useState(false);
-  const isVideoLink = title === VIDEO_TITLE;
+  const isVideoLink = type === "video";
   const windowStyles = {
     cursor: "pointer",
     backgroundImage: `url('https://res.cloudinary.com/dd4qvmhqx/image/upload/v1760470821/pencilwindow_icrhfu.svg')`,

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -1,7 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import { spacing } from "../styles";
 import Box from "@mui/material/Box";
-import { Link } from "gatsby";
+import Link from "@mui/material/Link";
+import Modal from "@mui/material/Modal";
+import Fade from "@mui/material/Fade";
+import Backdrop from "@mui/material/Backdrop";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+
+const VIDEO_TITLE = "Watch the SoulPad Video";
+
+function getYouTubeEmbedUrl(url: string): string {
+  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&]+)/);
+  return match ? `https://www.youtube.com/embed/${match[1]}?autoplay=1` : url;
+}
 
 interface WindowProps {
   title: string;
@@ -16,6 +28,8 @@ const Windows: React.FC<WindowProps> = ({
   maxWidth,
   minHeight,
 }) => {
+  const [videoModalOpen, setVideoModalOpen] = useState(false);
+  const isVideoLink = title === VIDEO_TITLE;
   const windowStyles = {
     cursor: "pointer",
     backgroundImage: `url('https://res.cloudinary.com/dd4qvmhqx/image/upload/v1760470821/pencilwindow_icrhfu.svg')`,
@@ -72,17 +86,127 @@ const Windows: React.FC<WindowProps> = ({
     },
   };
 
+  const handleVideoClick = () => {
+    if (isVideoLink) {
+      setVideoModalOpen(true);
+    }
+  };
+
+  const content = (
+    <>
+      {isVideoLink ? (
+        <Box
+          component="span"
+          onClick={handleVideoClick}
+          sx={{ cursor: "pointer", display: "contents" }}
+        >
+          <Box className="home-selection--text" sx={linkStyles}>
+            {title}
+          </Box>
+        </Box>
+      ) : (
+        <Link href={link} target="_blank" rel="noopener noreferrer" component="a" underline="none">
+          <Box className="home-selection--text" sx={linkStyles}>
+            {title}
+          </Box>
+        </Link>
+      )}
+    </>
+  );
+
+  const arrowContent = isVideoLink ? (
+    <Box
+      component="span"
+      onClick={handleVideoClick}
+      sx={{ cursor: "pointer", color: "transparent", display: "contents" }}
+    >
+      <Box className="home-selection--arrow" sx={arrowStyles} />
+    </Box>
+  ) : (
+    <Link
+      href={link}
+      component="a"
+      underline="none"
+      sx={{ color: "transparent" }}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Box className="home-selection--arrow" sx={arrowStyles} />
+    </Link>
+  );
+
   return (
     <Box className="home-selection--window" sx={windowStyles}>
-      <Link to={link}>
-        <Box className="home-selection--text" sx={linkStyles}>
-          {title}
-        </Box>
-      </Link>
+      {content}
+      {arrowContent}
 
-      <Link style={{ color: "transparent" }} to={link}>
-        <Box className="home-selection--arrow" sx={arrowStyles} />
-      </Link>
+      {isVideoLink && (
+      <Modal
+        open={videoModalOpen}
+        onClose={() => setVideoModalOpen(false)}
+        closeAfterTransition
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 500,
+            style: { backgroundColor: "rgba(0, 0, 0, 0.85)" },
+          },
+        }}
+      >
+        <Fade in={videoModalOpen}>
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              width: "90vw",
+              maxWidth: 900,
+              outline: "none",
+              p: 1,
+            }}
+          >
+            <IconButton
+              aria-label="close"
+              onClick={() => setVideoModalOpen(false)}
+              sx={{
+                position: "absolute",
+                right: 8,
+                top: 8,
+                color: "white",
+                backgroundColor: "rgba(0, 0, 0, 0.5)",
+                "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.7)" },
+                zIndex: 1,
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+            <Box
+              sx={{
+                position: "relative",
+                paddingBottom: "56.25%",
+                height: 0,
+                overflow: "hidden",
+              }}
+            >
+              <Box
+                component="iframe"
+                src={getYouTubeEmbedUrl(link)}
+                title="SoulPad Video"
+                sx={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: "100%",
+                  border: "none",
+                }}
+              />
+            </Box>
+          </Box>
+        </Fade>
+      </Modal>
+      )}
     </Box>
   );
 };

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -208,6 +208,7 @@ const Windows: React.FC<WindowProps> = ({
                 component="iframe"
                 src={getYouTubeEmbedUrl(link)}
                 title="SoulPad Video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 sx={{
                   position: "absolute",
                   top: 0,

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -97,63 +97,58 @@ const Windows: React.FC<WindowProps> = ({
     }
   };
 
-  const content = (
-    <>
-      {isVideoLink ? (
-        <Box
-          component="span"
-          onClick={handleVideoClick}
-          sx={{ cursor: "pointer", display: "contents" }}
-        >
-          <Box className="home-selection--text" sx={linkStyles}>
-            {title}
-          </Box>
-        </Box>
-      ) : isInternalLink(link) ? (
-        <Link component={GatsbyLink} to={link} underline="none">
-          <Box className="home-selection--text" sx={linkStyles}>
-            {title}
-          </Box>
-        </Link>
-      ) : (
-        <Link href={link} target="_blank" rel="noopener noreferrer" component="a" underline="none">
-          <Box className="home-selection--text" sx={linkStyles}>
-            {title}
-          </Box>
-        </Link>
-      )}
-    </>
-  );
+  function LinkWrapper({
+    children,
+    transparent,
+  }: {
+    children: React.ReactNode;
+    transparent?: boolean;
+  }) {
+    const linkSx = transparent ? { color: "transparent" as const } : undefined;
+    const videoSx = {
+      cursor: "pointer" as const,
+      ...(transparent && { color: "transparent" as const }),
+      display: "contents" as const,
+    };
 
-  const arrowContent = isVideoLink ? (
-    <Box
-      component="span"
-      onClick={handleVideoClick}
-      sx={{ cursor: "pointer", color: "transparent", display: "contents" }}
-    >
-      <Box className="home-selection--arrow" sx={arrowStyles} />
-    </Box>
-  ) : isInternalLink(link) ? (
-    <Link component={GatsbyLink} to={link} underline="none" sx={{ color: "transparent" }}>
-      <Box className="home-selection--arrow" sx={arrowStyles} />
-    </Link>
-  ) : (
-    <Link
-      href={link}
-      component="a"
-      underline="none"
-      sx={{ color: "transparent" }}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <Box className="home-selection--arrow" sx={arrowStyles} />
-    </Link>
-  );
+    if (isVideoLink) {
+      return (
+        <Box component="span" onClick={handleVideoClick} sx={videoSx}>
+          {children}
+        </Box>
+      );
+    }
+    if (isInternalLink(link)) {
+      return (
+        <Link component={GatsbyLink} to={link} underline="none" sx={linkSx}>
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <Link
+        href={link}
+        component="a"
+        underline="none"
+        sx={linkSx}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </Link>
+    );
+  }
 
   return (
     <Box className="home-selection--window" sx={windowStyles}>
-      {content}
-      {arrowContent}
+      <LinkWrapper>
+        <Box className="home-selection--text" sx={linkStyles}>
+          {title}
+        </Box>
+      </LinkWrapper>
+      <LinkWrapper transparent>
+        <Box className="home-selection--arrow" sx={arrowStyles} />
+      </LinkWrapper>
 
       {isVideoLink && (
       <Modal
@@ -208,7 +203,8 @@ const Windows: React.FC<WindowProps> = ({
                 component="iframe"
                 src={getYouTubeEmbedUrl(link)}
                 title="SoulPad Video"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
                 sx={{
                   position: "absolute",
                   top: 0,

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link as GatsbyLink } from "gatsby";
 import { spacing } from "../styles";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
@@ -7,6 +8,10 @@ import Fade from "@mui/material/Fade";
 import Backdrop from "@mui/material/Backdrop";
 import IconButton from "@mui/material/IconButton";
 import CloseIcon from "@mui/icons-material/Close";
+
+function isInternalLink(url: string): boolean {
+  return url.startsWith("/") && !url.startsWith("//");
+}
 
 const VIDEO_TITLE = "Watch the SoulPad Video";
 
@@ -104,6 +109,12 @@ const Windows: React.FC<WindowProps> = ({
             {title}
           </Box>
         </Box>
+      ) : isInternalLink(link) ? (
+        <Link component={GatsbyLink} to={link} underline="none">
+          <Box className="home-selection--text" sx={linkStyles}>
+            {title}
+          </Box>
+        </Link>
       ) : (
         <Link href={link} target="_blank" rel="noopener noreferrer" component="a" underline="none">
           <Box className="home-selection--text" sx={linkStyles}>
@@ -122,6 +133,10 @@ const Windows: React.FC<WindowProps> = ({
     >
       <Box className="home-selection--arrow" sx={arrowStyles} />
     </Box>
+  ) : isInternalLink(link) ? (
+    <Link component={GatsbyLink} to={link} underline="none" sx={{ color: "transparent" }}>
+      <Box className="home-selection--arrow" sx={arrowStyles} />
+    </Link>
   ) : (
     <Link
       href={link}

--- a/src/Components/Window.tsx
+++ b/src/Components/Window.tsx
@@ -20,6 +20,56 @@ function getYouTubeEmbedUrl(url: string): string {
   return match ? `https://www.youtube.com/embed/${match[1]}?autoplay=1` : url;
 }
 
+interface LinkWrapperProps {
+  children: React.ReactNode;
+  transparent?: boolean;
+  isVideoLink: boolean;
+  link: string;
+  onVideoClick: () => void;
+}
+
+function LinkWrapper({
+  children,
+  transparent,
+  isVideoLink,
+  link,
+  onVideoClick,
+}: LinkWrapperProps) {
+  const linkSx = transparent ? { color: "transparent" as const } : undefined;
+  const videoSx = {
+    cursor: "pointer" as const,
+    ...(transparent && { color: "transparent" as const }),
+    display: "contents" as const,
+  };
+
+  if (isVideoLink) {
+    return (
+      <Box component="span" onClick={onVideoClick} sx={videoSx}>
+        {children}
+      </Box>
+    );
+  }
+  if (isInternalLink(link)) {
+    return (
+      <Link component={GatsbyLink} to={link} underline="none" sx={linkSx}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <Link
+      href={link}
+      component="a"
+      underline="none"
+      sx={linkSx}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </Link>
+  );
+}
+
 interface WindowProps {
   title: string;
   link: string;
@@ -97,56 +147,20 @@ const Windows: React.FC<WindowProps> = ({
     }
   };
 
-  function LinkWrapper({
-    children,
-    transparent,
-  }: {
-    children: React.ReactNode;
-    transparent?: boolean;
-  }) {
-    const linkSx = transparent ? { color: "transparent" as const } : undefined;
-    const videoSx = {
-      cursor: "pointer" as const,
-      ...(transparent && { color: "transparent" as const }),
-      display: "contents" as const,
-    };
-
-    if (isVideoLink) {
-      return (
-        <Box component="span" onClick={handleVideoClick} sx={videoSx}>
-          {children}
-        </Box>
-      );
-    }
-    if (isInternalLink(link)) {
-      return (
-        <Link component={GatsbyLink} to={link} underline="none" sx={linkSx}>
-          {children}
-        </Link>
-      );
-    }
-    return (
-      <Link
-        href={link}
-        component="a"
-        underline="none"
-        sx={linkSx}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {children}
-      </Link>
-    );
-  }
+  const linkWrapperProps = {
+    isVideoLink,
+    link,
+    onVideoClick: handleVideoClick,
+  };
 
   return (
     <Box className="home-selection--window" sx={windowStyles}>
-      <LinkWrapper>
+      <LinkWrapper {...linkWrapperProps}>
         <Box className="home-selection--text" sx={linkStyles}>
           {title}
         </Box>
       </LinkWrapper>
-      <LinkWrapper transparent>
+      <LinkWrapper {...linkWrapperProps} transparent>
         <Box className="home-selection--arrow" sx={arrowStyles} />
       </LinkWrapper>
 

--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -23,12 +23,12 @@ export const homePageLinks = {
     url: "https://trysoulpaddemo.com/",
     type: "link",
   },
-  // video: {
-  //   id: "video",
-  //   label: "Watch the SoulPad Video",
-  //   url: "https://res.cloudinary.com/dd4qvmhqx/video/upload/v1760374008/soulpadVideo_dxorcc.mp4",
-  //   type: "video",
-  // },
+  video: {
+    id: "video",
+    label: "Watch the SoulPad Video",
+    url: "https://www.youtube.com/watch?v=1FEM6XuE5Qs",
+    type: "video",
+  },
 };
 
 export const FORMSPREEENDPOINT = "xdklakod";

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link, HeadFC, PageProps } from "gatsby";
+import { HeadFC, PageProps } from "gatsby";
 
 const pageStyles = {
   color: "#232129",
@@ -38,7 +38,7 @@ const NotFoundPage: React.FC<PageProps> = () => {
           </>
         ) : null}
         <br />
-        <Link to="/">Go home</Link>.
+        <a href="/">Go home</a>.
       </p>
     </main>
   );

--- a/src/pages/__tests__/Gallery.test.tsx
+++ b/src/pages/__tests__/Gallery.test.tsx
@@ -13,7 +13,7 @@ describe("Gallery Page", () => {
     expect(screen.getAllByText(/SoulPad/i)[0]).toBeInTheDocument();
     expect(screen.getByText(/Diary/i)).toBeInTheDocument();
     expect(screen.getByText(/Retrowave/i)).toBeInTheDocument();
-    expect(screen.getByText(/Video game/i)).toBeInTheDocument();
+    expect(screen.getByText("Video game")).toBeInTheDocument();
   });
 
   it("switches between themes when a theme button is clicked", async () => {
@@ -25,8 +25,8 @@ describe("Gallery Page", () => {
     expect(await findByText(/Diary/i)).toBeInTheDocument();
   });
 
-  it("renders the Custom List", () => {
+  it("renders the Messages card", () => {
     render(<Gallery />);
-    expect(screen.getByText(/Custom List/i)).toBeInTheDocument();
+    expect(screen.getByText(/Messages/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -13,10 +13,9 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the SoulPad introduction video", () => {
+  it("should render the SoulPad video window", () => {
     render(<Home />);
-    const video = screen.getByLabelText("SoulPad introduction video");
-    expect(video).toBeInTheDocument();
+    expect(screen.getAllByText(/Watch the SoulPad Video/i).length).toBeGreaterThan(0);
   });
 
   it("should render the newsletter banner", () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -251,6 +251,7 @@ const Home = () => {
                   key={key}
                   title={item.label}
                   link={item.url}
+                  type={item.type as "link" | "video"}
                   maxWidth="300px"
                   minHeight="180px"
                 />

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3,3 +3,4 @@ export * from "./colors";
 export * from "./fonts";
 export * from "./retro_1";
 export * from "./responsive";
+export { default as videoGameTheme } from "./videogameTheme/comps";

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "esnext"],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "esnext"],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Closes #23 
Closes #22 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/navigation changes and a new modal-based YouTube embed; main risk is regressions in routing behavior and link handling (internal vs external vs video) across the site.
> 
> **Overview**
> **Footer/navigation updates:** The footer is now responsive on mobile (column layout with no max-height) and only renders `homePageLinks` entries of type `link`.
> 
> **Home link + video window:** Several Gatsby `Link` usages are replaced with plain `<a>` tags (header logo and 404 “Go home”). The home page now supports a `video` entry in `homePageLinks`; `Window` can render either a normal link (internal via GatsbyLink or external via `target=_blank`) or open a modal with an embedded YouTube video when `type="video"`.
> 
> **Supporting changes:** Tests are updated to reflect the new video window and gallery card text expectations, `videoGameTheme` is re-exported from `styles`, and TypeScript JSX mode is switched to `react-jsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7be2ae03f95aa963957633384b5150910c2c6e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->